### PR TITLE
Update simple-talker-cmsg.c

### DIFF
--- a/simple-talker-cmsg/simple-talker-cmsg.c
+++ b/simple-talker-cmsg/simple-talker-cmsg.c
@@ -424,7 +424,7 @@ int run_tc_cmd(char *cmd, char **buf)
 	}
 
 	pclose(fp);
-	free(fp);
+	//free(fp);
 	fp = NULL;
 	return i;
 }


### PR DESCRIPTION
fix bug:

bug info:
detected domain Class A PRIO=0 VID=0000...
fix bug:
*** Error in `./simple-talker-cmsg': double free or corruption (!prev): 0x000055a30eeda5e0 ***
======= Backtrace: =========
......